### PR TITLE
[FEATURE] Emit signal after meta data extraction

### DIFF
--- a/Classes/Hook/FileUploadHook.php
+++ b/Classes/Hook/FileUploadHook.php
@@ -16,6 +16,7 @@ namespace Causal\Extractor\Hook;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
  * This class allows metadata to be extracted automatically after
@@ -62,6 +63,12 @@ class FileUploadHook implements \TYPO3\CMS\Core\Utility\File\ExtendedFileUtility
                 $storageRecord = $fileObject->getStorage()->getStorageRecord();
                 if ($storageRecord['driver'] === 'Local') {
                     $this->runMetaDataExtraction($fileObject);
+                    // Emit Signal after meta data has been extracted
+                    $this->getSignalSlotDispatcher()->dispatch(
+                        self::class,
+                        'postMetaDataExtraction',
+                        [$storageRecord]
+                    );
                 }
             }
         }
@@ -138,5 +145,15 @@ class FileUploadHook implements \TYPO3\CMS\Core\Utility\File\ExtendedFileUtility
         }
 
         return $logger;
+    }
+
+    /**
+     * Returns the SignalSlot dispatcher.
+     *
+     * @return \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
+     */
+    protected function getSignalSlotDispatcher()
+    {
+        return GeneralUtility::makeInstance(Dispatcher::class);
     }
 }

--- a/Classes/Service/AbstractService.php
+++ b/Classes/Service/AbstractService.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
  * Abstract service.
@@ -59,7 +60,12 @@ abstract class AbstractService implements ServiceInterface
         $localTempFilePath = $file->getForLocalProcessing(false);
         $metadata = $this->extractMetadataFromLocalFile($localTempFilePath);
         $this->cleanupTempFile($localTempFilePath, $file);
-
+        // Emit Signal after meta data has been extracted
+        $this->getSignalSlotDispatcher()->dispatch(
+            'AbstractService',
+            'postMetaDataExtraction',
+            [$storageRecord]
+        );
         return $metadata;
     }
 
@@ -121,5 +127,15 @@ abstract class AbstractService implements ServiceInterface
         }
 
         return $logger;
+    }
+
+    /**
+     * Returns the SignalSlot dispatcher.
+     *
+     * @return \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
+     */
+    protected function getSignalSlotDispatcher()
+    {
+        return GeneralUtility::makeInstance(Dispatcher::class);
     }
 }

--- a/Documentation/DeveloperManual/Index.rst
+++ b/Documentation/DeveloperManual/Index.rst
@@ -78,3 +78,30 @@ Hook
 The method ``\Causal\Extractor\Service\Extraction\AbstractExtractionService::getDataMapping()`` is the central method
 invoked to map extracted metadata to FAL properties. Developers may dynamically alter the mapping by hooking into the
 process using ``$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extractor']['dataMappingHook']``.
+
+
+.. _developer-manual-signal:
+
+Signal after extraction
+-----------------------
+
+Once the meta data has been extracted, a signal is emitted, which allows other extensions to process the file further.
+The Signal can be connected to a Slot as follows (e.g. in file ``ext_localconf.php`` of your extension).
+
+.. code-block:: php
+
+    // Initiate SignalSlotDispatcher
+    $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        'TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher'
+    );
+
+    // Connect the Signal "postMetaDataExtraction" to a Slot
+    $signalSlotDispatcher->connect(
+        'Causal\\Extractor\\Service\\AbstractService',
+        'postMetaDataExtraction',
+        'Vendor\\MyExtension\\Service\\SlotService',
+        'dispatch'
+    );
+
+This requires a PHP class ``\Vendor\MyExtension\Service\SlotService`` and a method ``dispatch()`` in this class.
+The FAL ``$storageRecord`` is passed as a parameter to the method.


### PR DESCRIPTION
This new feature emits a Signal after the meta data has been extracted. By connecting the Signal to a Slot, other extensions can process the file further. Further details are documented in the manual (chapter "Developer Manual").