### PR TITLE
[BUGFIX] Use FQCN when emitting the Signal

### DIFF
--- a/Classes/Service/AbstractService.php
+++ b/Classes/Service/AbstractService.php
@@ -62,7 +62,7 @@ abstract class AbstractService implements ServiceInterface
         $this->cleanupTempFile($localTempFilePath, $file);
         // Emit Signal after meta data has been extracted
         $this->getSignalSlotDispatcher()->dispatch(
-            'AbstractService',
+            self::class,
             'postMetaDataExtraction',
             [$storageRecord]
         );

--- a/Classes/Service/AbstractService.php
+++ b/Classes/Service/AbstractService.php
@@ -64,7 +64,7 @@ abstract class AbstractService implements ServiceInterface
         $this->getSignalSlotDispatcher()->dispatch(
             self::class,
             'postMetaDataExtraction',
-            [$storageRecord]
+            [$file]
         );
         return $metadata;
     }


### PR DESCRIPTION
When dispatching the SignalSlot after meta data of a file has been extracted, the **fully qualified class name** of the class should used, rather than just `AbstractService`. This matches the official TYPO3 standard and documentation included in this extension.

Secondly, a wrong variable name was used (`$storageRecord`), which has been fixed in commit 72a79c6b525fc5e4ee5578130601d6035257dc27.