### PR TITLE
Change database type of field "copyright" to "text"

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,7 +2,7 @@
 # Table structure for table 'sys_file_metadata'
 #
 CREATE TABLE sys_file_metadata (
-  copyright varchar(255) DEFAULT '' NOT NULL,
+  copyright text,
   camera_make varchar(255) DEFAULT '' NOT NULL,
   camera_model varchar(255) DEFAULT '' NOT NULL,
   camera_lens varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
Since TYPO3 V7 the field `copyright` in the core Extension `sys_file_metadata` has changed to the type `text`, since copyright information often contain more than 255 chars.

Forge Issue: https://forge.typo3.org/issues/78149

When using a current version of TYPO3 core and ext:extractor, the field type is changed back to varchar(255), because the extension overrides the defaults from `sys_file_metadata`. Therefore, the type of the field `copyright` should be changed to `text` in order to allow content with more than 255 chars.