### PR TITLE
Add 'language'

### DIFF
--- a/Configuration/Services/Pdfinfo/default.json
+++ b/Configuration/Services/Pdfinfo/default.json
@@ -56,5 +56,9 @@
     "DATA": [
       "Title"
     ]
+  },
+  {
+    "FAL": "language",
+    "DATA": "Language"
   }
 ]


### PR DESCRIPTION
I made a small patch for pdfinfo to show the language field:
https://forum.xpdfreader.com/viewtopic.php?p=43339#p43339
Together with this patch for ke_search it is possible to set the language field there also:
https://github.com/teaminmedias-pluswerk/ke_search/commit/d9d892e38837836fe4d45e507050a35b07b5d23e#diff-91c5b46dc84a94604a4e4d0caed9bf85590a2eddbb12d2e8dc80badf324a9dfb