### PR TITLE
[BUGFIX] Avoid exception when no metadata given

### DIFF
--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -122,7 +122,7 @@ class ServerService extends AbstractService implements TikaServiceInterface
         $content = $this->send('PUT', '/meta', 'application/json', $fileName);
         $metadata = json_decode($content, true);
 
-        return $metadata;
+        return $metadata ?? [];
     }
 
     /**


### PR DESCRIPTION
When Tika cannot extract metadata for a single file, the whole process l(ike in scheduler run) dies with exception
Core: Exception handler (CLI): Uncaught TYPO3 Exception: Argument 2 passed to Causal\Extractor\Resource\Event\AfterMetadataExtractedEvent::__construct() must be of the type array, null given