### PR TITLE
fix: Coerce `iso_speed` to integer, matching EXIF specification

### DIFF
--- a/Configuration/Services/ExifTool/default.json
+++ b/Configuration/Services/ExifTool/default.json
@@ -159,7 +159,7 @@
   },
   {
     "FAL": "iso_speed",
-    "DATA": "BaseISO"
+    "DATA": "BaseISO->Causal\\Extractor\\Utility\\Number::castInteger"
   },
   {
     "FAL": "aperture",

--- a/Configuration/Services/Php/default.json
+++ b/Configuration/Services/Php/default.json
@@ -159,7 +159,7 @@
   },
   {
     "FAL": "iso_speed",
-    "DATA": "ISOSpeedRatings->Causal\\Extractor\\Utility\\Number::castInteger"
+    "DATA": "ISOSpeedRatings->Causal\\Extractor\\Utility\\Array_::concatenate(' ')->Causal\\Extractor\\Utility\\Number::castInteger"
   },
   {
     "FAL": "aperture",

--- a/Configuration/Services/Php/default.json
+++ b/Configuration/Services/Php/default.json
@@ -159,7 +159,7 @@
   },
   {
     "FAL": "iso_speed",
-    "DATA": "ISOSpeedRatings"
+    "DATA": "ISOSpeedRatings->Causal\\Extractor\\Utility\\Number::castInteger"
   },
   {
     "FAL": "aperture",

--- a/Configuration/Services/Tika/default.json
+++ b/Configuration/Services/Tika/default.json
@@ -159,7 +159,7 @@
   },
   {
     "FAL": "iso_speed",
-    "DATA": "exif:IsoSpeedRatings"
+    "DATA": "exif:IsoSpeedRatings->Causal\\Extractor\\Utility\\Number::castInteger"
   },
   {
     "FAL": "aperture",


### PR DESCRIPTION
Fixes https://github.com/xperseguers/t3ext-extractor/issues/48 and https://github.com/xperseguers/t3ext-extractor/issues/39

The EXIF field `ISOSpeedRatings` is defined as `SHORT` integer. Some camera models use invalid string values like `"100 0"` or `"125, 0"`.

TYPO3 and `EXT:extractor` should handle such invalid values with grace and normalize the input.
Before this patch, however, TYPO3 panics with MariaDB script mode error `Data truncated for column 'iso_speed' at row 1`.
