### PR TITLE
Parse meta data with empty values properly.

### DIFF
--- a/Classes/Service/Pdfinfo/PdfinfoService.php
+++ b/Classes/Service/Pdfinfo/PdfinfoService.php
@@ -77,7 +77,7 @@ class PdfinfoService extends AbstractService
 
         $metadata = [];
         foreach ($shellOutput as $line) {
-            list($key, $value) = GeneralUtility::trimExplode(':', $line, true, 2);
+            list($key, $value) = GeneralUtility::trimExplode(':', $line, false, 2);
             $metadata[$key] = $value;
         }
 


### PR DESCRIPTION
Prevents warnings on PHP 8. Parses empty values as empty strings instead of `null` values.

Fixes #55.