### PR TITLE
Harden is_array() check

### DIFF
--- a/Classes/Service/ExifTool/ExifToolService.php
+++ b/Classes/Service/ExifTool/ExifToolService.php
@@ -98,7 +98,7 @@ class ExifToolService extends AbstractService
 
         $metadata = json_decode(implode('', $shellOutput), true);
 
-        if (is_array($metadata[0]['Creator'])) {
+        if (is_array($metadata[0]['Creator'] ?? null)) {
             $metadata[0]['Creator'] = end($metadata[0]['Creator']);
         }
 


### PR DESCRIPTION
Creator key may be missing (for example in case of SVG files).