### PR TITLE
Add utility method as replacement for GeneralUtility::isFirstPartOfStr()

### DIFF
--- a/Classes/Em/AbstractConfigurationField.php
+++ b/Classes/Em/AbstractConfigurationField.php
@@ -14,6 +14,7 @@
 
 namespace Causal\Extractor\Em;
 
+use Causal\Extractor\Utility\SimpleString;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -34,7 +35,7 @@ abstract class AbstractConfigurationField
      */
     protected function translate($id, $hsc = false, array $arguments = null)
     {
-        if (!GeneralUtility::isFirstPartOfStr($id, 'LLL:EXT:')) {
+        if (!SimpleString::isFirstPartOfStr($id, 'LLL:EXT:')) {
             $reference = 'LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:' . $id;
         } else {
             $reference = $id;

--- a/Classes/Em/AjaxController.php
+++ b/Classes/Em/AjaxController.php
@@ -17,6 +17,7 @@ namespace Causal\Extractor\Em;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Causal\Extractor\Service;
+use Causal\Extractor\Utility\SimpleString;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Resource\FileInterface;
@@ -206,7 +207,7 @@ class AjaxController
         /** @var \TYPO3\CMS\Core\Resource\ResourceFactory $resourceFactory */
         $resourceFactory = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\ResourceFactory::class);
 
-        if (GeneralUtility::isFirstPartOfStr($reference, $extensionPrefix)) {
+        if (SimpleString::isFirstPartOfStr($reference, $extensionPrefix)) {
             $fileName = substr($reference, strlen($extensionPrefix));
             $recordData = [
                 'uid' => 0,

--- a/Classes/Em/MappingController.php
+++ b/Classes/Em/MappingController.php
@@ -14,6 +14,7 @@
 
 namespace Causal\Extractor\Em;
 
+use Causal\Extractor\Utility\SimpleString;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -284,10 +285,10 @@ CSS;
             ->listTableColumns('sys_file_metadata');
         foreach ($fields as $field => $_) {
             switch (true) {
-                case GeneralUtility::isFirstPartOfStr($field, 't3ver_'):
-                case GeneralUtility::isFirstPartOfStr($field, 't3_'):
-                case GeneralUtility::isFirstPartOfStr($field, 'l10n_'):
-                case GeneralUtility::isFirstPartOfStr($field, 'zzz_deleted_'):
+                case SimpleString::isFirstPartOfStr($field, 't3ver_'):
+                case SimpleString::isFirstPartOfStr($field, 't3_'):
+                case SimpleString::isFirstPartOfStr($field, 'l10n_'):
+                case SimpleString::isFirstPartOfStr($field, 'zzz_deleted_'):
                 case in_array($field, ['uid', 'pid', 'tstamp', 'crdate', 'cruser_id', 'file', 'sys_language_uid', 'fe_groups']):
                     // Nothing to do
                     break;

--- a/Classes/Utility/SimpleString.php
+++ b/Classes/Utility/SimpleString.php
@@ -40,4 +40,20 @@ class SimpleString
         $str = preg_replace('/[\x00-\x1F]/', '', $str);
         return trim($str);
     }
+
+
+    /**
+     * Returns true if the passed $haystack starts from the $needle string or false otherwise.
+     *
+     * @internal Calls `str_starts_with` on modern TYPO3 installations (TYPO3 10.4 or newer / PHP 8.0 or newer),
+     * falls back to GeneralUtility::isFirstPartOfStr() on legacy TYPO3 installations.
+     *
+     * @param string $haystack
+     * @param string $needle
+     * @return bool
+     */
+    public static function isFirstPartOfStr(string $haystack, string $needle): bool
+    {
+        return function_exists('str_starts_with') ? str_starts_with($haystack, $needle) : GeneralUtility::isFirstPartOfStr($haystack, $needle);
+    }
 }


### PR DESCRIPTION
The utility method uses `str_starts_with` under the hood with a fallback to `GeneralUtility::isFirstPartOfStr()` on legacy installations.

Motivation: `GeneralUtility::isFirstPartOfStr()` has been deprecated in TYPO3 11.5 and removed in TYPO3 12

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95257-GeneralUtilityisFirstPartOfStr.html

Related: #58