### PR TITLE
Use `fieldName` instead of `propertyName`

### DIFF
--- a/Classes/Em/ConfigurationHelper.php
+++ b/Classes/Em/ConfigurationHelper.php
@@ -39,7 +39,7 @@ class ConfigurationHelper extends AbstractConfigurationField
     {
         $html = $this->createFormInputField([
             'name' => $params['fieldName'],
-            'id' => 'em-' . $params['propertyName'],
+            'id' => 'em-' . $params['fieldName'],
             'class' => 'form-control',
             'placeholder' => '/path/to/tika-app-x.x.jar',
             'value' => $params['fieldValue'],
@@ -82,7 +82,7 @@ class ConfigurationHelper extends AbstractConfigurationField
     {
         $html = $this->createFormInputField([
             'name' => $params['fieldName'],
-            'id' => 'em-' . $params['propertyName'],
+            'id' => 'em-' . $params['fieldName'],
             'class' => 'form-control',
             'placeholder' => 'localhost',
             'value' => $params['fieldValue'],
@@ -128,7 +128,7 @@ class ConfigurationHelper extends AbstractConfigurationField
      */
     public function createToolInput(array $params, $pObj)
     {
-        $externalTool = explode('_', $params['propertyName']);
+        $externalTool = explode('_', $params['fieldName']);
         $externalTool = $externalTool[1];
 
         if (empty($params['fieldValue'])) {
@@ -141,7 +141,7 @@ class ConfigurationHelper extends AbstractConfigurationField
 
         $html = $this->createFormInputField([
             'name' => $params['fieldName'],
-            'id' => 'em-' . $params['propertyName'],
+            'id' => 'em-' . $params['fieldName'],
             'class' => 'form-control',
             'placeholder' => '/path/to/' . $externalTool,
             'value' => $params['fieldValue'],


### PR DESCRIPTION
The latter is no more provided in TYPO3 12.

Fixes #65.

Relates to #58.