### PR TITLE
fixed deprecation crash (passing null to json_decode())

### DIFF
--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -120,9 +120,8 @@ class ServerService extends AbstractService implements TikaServiceInterface
     public function extractMetadataFromLocalFile($fileName)
     {
         $content = $this->send('PUT', '/meta', 'application/json', $fileName);
-        $metadata = json_decode($content, true);
-
-        return $metadata ?? [];
+        $metadata = empty($content) ? [] : json_decode($content, true);
+        return $metadata;
     }
 
     /**


### PR DESCRIPTION
You cannot pass NULL to json_decode anymore... this prevents the file from being uploaded by using for example StorageRepository->addFile()