### PR TITLE
Add service for fetching metadata from online media providers (Youtube + Vimeo)

### DIFF
--- a/Classes/Service/Api/ApiService.php
+++ b/Classes/Service/Api/ApiService.php
@@ -1,0 +1,195 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Extractor\Service\Api;
+
+use Causal\Extractor\Service\AbstractService;
+use Causal\Extractor\Utility\ColorSpace;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Resource\File;
+
+use Causal\Extractor\Resource\Event\AfterMetadataExtractedEvent;
+
+/**
+ * A ApiService service implementation.
+ *
+ * @author      --- <xavier@causal.ch>
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ */
+class ApiService extends AbstractService
+{
+    /** @var array */
+    protected $onlineExtensions = [
+        'youtube',  // VIDEOTYPE_YOUTUBE
+        'vimeo',    // VIDEOTYPE_VIMEO
+    ];
+
+
+    
+
+    /**
+     * Returns a list of supported file types.
+     *
+     * @return array
+     */
+    public function getSupportedFileExtensions()
+    {
+        return array_merge(
+            $this->onlineExtensions
+        );
+    }
+
+    /**
+     * Takes a file reference and extracts its metadata.
+     *
+     * @param \TYPO3\CMS\Core\Resource\File $file Path to the file
+     * @return array
+     * @see \Causal\ImageAutoresize\Utility\ImageUtility::getMetadata()
+     */
+    public function extractMetadataFromLocalFile($file)
+    {
+        $fileName = $file->getForLocalProcessing(false);
+        $extension = strtolower(substr($fileName, strrpos($fileName, '.') + 1));
+        
+        //ok
+        error_log("extension navn:");
+        
+        error_log($extension);
+
+        try {
+            switch (true) {
+                
+                // case in_array($extension, $this->getOnlineExtensions):
+                //     $metadata = $this->extractMetadataWithGetId3($fileName);
+                //     break;
+                case $extension === 'youtube':
+                    $metadata = $this->extractMetadataFromYoutube($file);
+                    break;
+                case $extension === 'vimeo':
+                    $metadata = $this->extractMetadataFromVimeo($file);
+                    break;
+                default:
+                    $metadata = [];
+                    break;
+            }
+            $this->cleanupTempFile($fileName, $file);
+
+            static::getLogger()->debug('Metadata extracted', $metadata);
+        } catch (\Exception $e) {
+            static::getLogger()->error('Error while extracting metadata from file', ['exception' => $e]);
+            $metadata = [];
+        }
+        
+        
+        error_log("metadate første tomme array:");
+        error_log(print_r($metadata, true));
+        return $metadata;
+    }
+
+    
+
+
+    /**
+     * Takes a file reference and extracts its metadata.
+     *
+     * @param File $file
+     * @return array
+     */
+    public function extractMetadata(File $file)
+    {
+        static::getLogger()->debug(
+            'Extracting metadata',
+            [
+                'file' => $file->getUid(),
+                'identifier' => $file->getCombinedIdentifier(),
+            ]
+        );
+        #$localTempFilePath = $file->getForLocalProcessing(false);
+        $metadata = $this->extractMetadataFromLocalFile($file);
+        #$this->cleanupTempFile($localTempFilePath, $file);
+
+        // Emit Signal after metadata has been extracted
+        if ($this->eventDispatcher !== null) {
+            $event = new AfterMetadataExtractedEvent($file, $metadata);
+            $this->eventDispatcher->dispatch($event);
+            $metadata = $event->getMetadata();
+        } else {
+            $this->getSignalSlotDispatcher()->dispatch(
+                self::class,
+                'postMetaDataExtraction',
+                [
+                    $file,
+                    &$metadata
+                ]
+            );
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Fetch metadata from a youtube video.
+     *
+     * @param \TYPO3\CMS\Core\Resource\File $file File object
+     * @return array
+     */
+    protected function extractMetadataFromYoutube($file)
+    {
+        static::getLogger()->debug('Fetching metadata from Youtube API');
+        $metadata = [];
+
+        // Fetch online media id
+        $onlineMediaHelper = OnlineMediaHelperRegistry::getInstance()->getOnlineMediaHelper($file);
+        $videoId = $onlineMediaHelper->getOnlineMediaId($file);
+        
+        $params = array(
+            'part' => 'contentDetails,snippet', // snippet has description
+            'id' => $videoId,
+            'key' => $this->settings['youtube_api_key'],
+        );
+
+        $api_url = $this->settings['youtube_api_base'] . '?' . http_build_query($params);
+        
+        $result = json_decode(@file_get_contents($api_url), true);
+
+        if(empty($result['items'][0]['contentDetails'])) {
+            return null;
+        }
+        
+        $duration = self::covTime($result['items'][0]['contentDetails']['duration']);
+        $metadata['duration'] = $duration;
+
+        return $metadata;
+
+    }
+
+
+    /**
+     * Convert Youtube time
+     *
+     * @param string $youtubeTime
+     */
+    public function covTime($youtubeTime)
+    {
+        $start = new \DateTime('@0'); // Unix epoch
+        $start->add(new \DateInterval($youtubeTime));
+        return $start->format('U');
+    }
+
+}
+

--- a/Classes/Service/Extraction/ApiMetadataExtraction.php
+++ b/Classes/Service/Extraction/ApiMetadataExtraction.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * A service to extract metadata from files using API
  *
- * @author      Xavier Perseguers <xavier@causal.ch>
+ * @author      Martin Kristensen <mkr@imh.dk>
  * @license     http://www.gnu.org/copyleft/gpl.html
  */
 class ApiMetadataExtraction extends AbstractExtractionService
@@ -73,8 +73,6 @@ class ApiMetadataExtraction extends AbstractExtractionService
 
         $extractedMetadata = $this->getApiService()->extractMetadata($file);
 
-        error_log(print_r($extractedMetadata, true));
-        
         if (!empty($extractedMetadata)) {
             $dataMapping = $this->getDataMapping($file);
             $metadata = $this->remapServiceOutput($extractedMetadata, $dataMapping);

--- a/Classes/Service/Extraction/ApiMetadataExtraction.php
+++ b/Classes/Service/Extraction/ApiMetadataExtraction.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Extractor\Service\Extraction;
+
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * A service to extract metadata from files using API
+ *
+ * @author      Xavier Perseguers <xavier@causal.ch>
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ */
+class ApiMetadataExtraction extends AbstractExtractionService
+{
+    /**
+     * @var integer
+     */
+    protected $priority = 50;
+
+    /**
+     * @var string
+     */
+    protected $serviceName = 'Api';
+
+    /**
+     * ApiMetadataExtraction constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $apiService = $this->getApiService();
+        $this->supportedFileExtensions = $apiService->getSupportedFileExtensions();
+    }
+
+    /**
+     * Checks if the given file can be processed by this extractor.
+     *
+     * @param File $file
+     * @return boolean
+     */
+    protected function _canProcess(File $file): bool
+    {
+        $fileExtension = strtolower($file->getProperty('extension'));
+        return in_array($fileExtension, $this->supportedFileExtensions);
+    }
+
+    /**
+     * The actual processing task.
+     *
+     * Should return an array with database properties for sys_file_metadata to write.
+     *
+     * @param File $file
+     * @param array $previousExtractedData optional, contains the array of already extracted data
+     * @return array
+     */
+    public function extractMetaData(File $file, array $previousExtractedData = [])
+    {
+        $metadata = [];
+
+        $extractedMetadata = $this->getApiService()->extractMetadata($file);
+
+        error_log(print_r($extractedMetadata, true));
+        
+        if (!empty($extractedMetadata)) {
+            $dataMapping = $this->getDataMapping($file);
+            $metadata = $this->remapServiceOutput($extractedMetadata, $dataMapping);
+            $this->processCategories($file, $metadata);
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Returns a API service.
+     *
+     * @return \Causal\Extractor\Service\Api\ApiService
+     */
+    protected function getApiService()
+    {
+        /** @var \Causal\Extractor\Service\Api\ApiService $apiService */
+        static $apiService = null;
+
+        if ($apiService === null) {
+            $apiService = GeneralUtility::makeInstance(\Causal\Extractor\Service\Api\ApiService::class);
+        }
+
+        return $apiService;
+    }
+
+    /**
+     * Returns a logger.
+     *
+     * @return \TYPO3\CMS\Core\Log\Logger
+     */
+    protected static function getLogger()
+    {
+        /** @var \TYPO3\CMS\Core\Log\Logger $logger */
+        $logger = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Log\LogManager::class)->getLogger(__CLASS__);
+        return $logger;
+    }
+}

--- a/Classes/Utility/ExtensionHelper.php
+++ b/Classes/Utility/ExtensionHelper.php
@@ -132,6 +132,9 @@ class ExtensionHelper
             case 'wmv':
             case 'yuv':
                 return 'video';
+            case 'youtube':
+            case 'vimeo':
+                return 'onlinemedia';
         }
 
         return 'other';

--- a/Classes/Utility/YoutubeTime.php
+++ b/Classes/Utility/YoutubeTime.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Extractor\Utility;
+
+/**
+ * Youtube time utility class.
+ *
+ * @author      Daniel Alexander Damm <dad@imh.dk>
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ */
+class YoutubeTime
+{
+    /**
+     * Convert Youtube time
+     *
+     * @param string $youtubeTime
+     * @return int
+     */
+    public static function toSeconds($youtubeTime) : int
+    {
+        $start = new \DateTime('@0'); // Unix epoch
+        $start->add(new \DateInterval($youtubeTime));
+        return (int)$start->format('U');
+    }
+}

--- a/Configuration/Services/Api/onlinemedia.json
+++ b/Configuration/Services/Api/onlinemedia.json
@@ -1,0 +1,6 @@
+[
+    {
+      "FAL": "duration",
+      "DATA": "duration->Causal\\Extractor\\Utility\\Number::castInteger"
+    }
+]    

--- a/Configuration/Services/Api/onlinemedia.json
+++ b/Configuration/Services/Api/onlinemedia.json
@@ -1,11 +1,22 @@
 [
     {
       "FAL": "duration",
-      "DATA": "duration->Causal\\Extractor\\Utility\\Number::castInteger"
+      "DATA": [
+        "youtube|contentDetails|duration->Causal\\Extractor\\Utility\\YoutubeTime::toSeconds",
+        "vimeo|duration->Causal\\Extractor\\Utility\\Number::castInteger"
+      ]
     },
     {
       "FAL": "description",
-      "DATA": "description"
+      "DATA": [
+        "youtube|snippet|description->Causal\\Extractor\\Utility\\SimpleString::trim",
+        "vimeo|description->Causal\\Extractor\\Utility\\SimpleString::trim"
+      ]
+    },
+    {
+      "FAL": "publisher",
+      "DATA": [
+        "vimeo|user|name->Causal\\Extractor\\Utility\\SimpleString::trim"
+      ]
     }
 ]
-

--- a/Configuration/Services/Api/onlinemedia.json
+++ b/Configuration/Services/Api/onlinemedia.json
@@ -2,5 +2,10 @@
     {
       "FAL": "duration",
       "DATA": "duration->Causal\\Extractor\\Utility\\Number::castInteger"
+    },
+    {
+      "FAL": "description",
+      "DATA": "description"
     }
-]    
+]
+

--- a/Resources/Private/Language/locallang_em.xlf
+++ b/Resources/Private/Language/locallang_em.xlf
@@ -12,6 +12,9 @@
             <trans-unit id="settings.category.tools">
                 <source>External Tools</source>
             </trans-unit>
+            <trans-unit id="settings.category.online">
+                <source>Online Media</source>
+            </trans-unit>
             <trans-unit id="settings.enable_tika">
                 <source>Apache Tika: If ticked, Apache Tika will be used to detect and extract metadata from your assets.</source>
             </trans-unit>
@@ -23,6 +26,9 @@
             </trans-unit>
             <trans-unit id="settings.enable_php">
                 <source>Native PHP: If ticked, native PHP code and libraries will be used to detect and extract metadata from your assets.</source>
+            </trans-unit>
+            <trans-unit id="settings.enable_api">
+                <source>API: If ticked, API code will be used to fetch metadata for your assets. Remember to fill out Online media tokens.</source>
             </trans-unit>
             <trans-unit id="settings.mapping_base_directory">
                 <source>Base directory for mapping: The metadata extraction requires mapping configuration files. By default these are provided in the Configuration/Services directory. If you wish to use a different mapping configuration, you can provide a different mapping configuration base directory.</source>
@@ -103,6 +109,24 @@
             </trans-unit>
             <trans-unit id="settings.mapping_configuration.json.copy">
                 <source>copy JSON to clipboard</source>
+            </trans-unit>
+            <trans-unit id="settings.online_youtube_api_key">
+                <source>Api key from Youtube : https://developers.google.com/youtube/v3/docs/</source>
+            </trans-unit>
+            <trans-unit id="settings.online_youtube_api_base">
+                <source>Baseurl for Youtube Api calls</source>
+            </trans-unit>
+            <trans-unit id="settings.online_youtube_thumbnail_base">
+                <source>Url for Youtube thumbnail provider</source>
+            </trans-unit>
+            <trans-unit id="settings.online_vimeo_api_key">
+                <source>Api key from Vimeo : https://developers.google.com/youtube/v3/docs/</source>
+            </trans-unit>
+            <trans-unit id="settings.online_vimeo_api_base">
+                <source>Baseurl for Vimeo Api calls</source>
+            </trans-unit>
+            <trans-unit id="settings.online_vimeo_thumbnail_base">
+                <source>Url for Vimeo thumbnail provider</source>
             </trans-unit>
         </body>
     </file>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,6 +1,7 @@
 # customcategory=mapping=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.category.mapping
 # customcategory=tika=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.category.tika
 # customcategory=tools=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.category.tools
+# customcategory=online=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.category.online
 
 # cat=basic/enable/10; type=boolean; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.enable_tika
 enable_tika = 0
@@ -13,6 +14,9 @@ enable_tools_pdfinfo = 0
 
 # cat=basic/enable/40; type=boolean; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.enable_php
 enable_php = 1
+
+# cat=basic/enable/50; type=boolean; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.enable_api
+enable_api = 0
 
 # cat=tika//10; type=options[LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.tika_mode.jar=jar,LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.tika_mode.server=server]; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.tika_mode
 tika_mode = jar
@@ -31,6 +35,24 @@ tools_exiftool =
 
 # cat=tools//30; type=user[Causal\Extractor\Em\ConfigurationHelper->createToolInput]; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.tools_pdfinfo
 tools_pdfinfo =
+
+# cat=online//10; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.online_youtube_api_key
+youtube_api_key =
+
+# cat=online//20; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.online_youtube_api_base
+youtube_api_base = https://www.googleapis.com/youtube/v3/videos
+
+# cat=online//30; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.online_youtube_thumbnail_base
+youtube_thumbnail_base = https://i.ytimg.com/vi/
+
+# cat=online//40; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.online_vimeo_api_key
+vimeo_api_key =
+
+# cat=online//50; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.online_vimeo_api_base
+vimeo_api_base = https://api.vimeo.com/videos/
+
+# cat=online//60; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.online_vimeo_thumbnail_base
+vimeo_thumbnail_base = 
 
 # cat=mapping//10; type=string; label=LLL:EXT:extractor/Resources/Private/Language/locallang_em.xlf:settings.mapping_base_directory
 mapping_base_directory = EXT:extractor/Configuration/Services/

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,5 +29,9 @@ defined('TYPO3_MODE') || defined('TYPO3') || die();
         if (!isset($settings['enable_php']) || (bool)$settings['enable_php']) {
             $extractorRegistry->registerExtractionService(\Causal\Extractor\Service\Extraction\PhpMetadataExtraction::class);
         }
+        // Mind the "!isset" in test below to be backward compatible
+        if (!isset($settings['enable_api']) || (bool)$settings['enable_api']) {
+            $extractorRegistry->registerExtractionService(\Causal\Extractor\Service\Extraction\ApiMetadataExtraction::class);
+        }
     }
 })('extractor');


### PR DESCRIPTION
We were working on an update for a private extension that provided metadata extraction from MP3, Vimeo, and YouTube when we discovered Extractor. Extractor already handles MP3 files and has a great integration with FAL, but it lacked metadata extraction from online media providers. Therefore, we added a new service and integrated some of our existing code into the project.

Both the YouTube and Vimeo APIs require an API key, which can be set in the extension configuration. We hope this addition is useful for others as well.

Best regards,

Daniel and Martin
Indre Mission, Denmark